### PR TITLE
monodb-mysql/pgsql-health.sh: Add Direct Message alarm support

### DIFF
--- a/.bin/monodb-mysql-health.conf
+++ b/.bin/monodb-mysql-health.conf
@@ -1,6 +1,11 @@
     ALARM_WEBHOOK_URL=example.com
+    ALARM_BOT_API_URL=https://example.com
+    ALARM_BOT_EMAIL=test-bot@example.com
+    ALARM_BOT_API_KEY=testkey
+    ALARM_BOT_USER_EMAIL=user@example.com
     IDENTIFIER="test"
     SEND_ALARM=1
+    SEND_DM_ALARM=1
     PROCESS_LIMIT=50
     IS_CLUSTER=0
     CLUSTER_SIZE=3  

--- a/.bin/monodb-pgsql-health.conf
+++ b/.bin/monodb-pgsql-health.conf
@@ -1,4 +1,9 @@
 ALARM_WEBHOOK_URL=example.com
+ALARM_BOT_API_URL=https://example.com
+ALARM_BOT_EMAIL=test-bot@example.com
+ALARM_BOT_API_KEY=testkey
+ALARM_BOT_USER_EMAIL=user@example.com
 IDENTIFIER="test"
 PATRONI_API="http://localhost:8008/cluster"
 SEND_ALARM=1
+SEND_DM_ALARM=1

--- a/monodb/monodb-mysql-health.sh
+++ b/monodb/monodb-mysql-health.sh
@@ -35,9 +35,17 @@ function print_colour() {
 }
 
 function alarm() {
-    if [ "$SEND_ALARM" == "1" ]; then
-        curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
-    fi
+      if [ "$SEND_ALARM" == "1" ]; then
+          curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
+      fi
+	
+      if [ "$SEND_DM_ALARM" = "1" ] && [ -n "$ALARM_BOT_API_KEY" ] && [ -n "$ALARM_BOT_EMAIL" ] && [ -n "$ALARM_BOT_API_URL" ] && [ -n "$ALARM_BOT_USER_EMAIL" ]; then
+            curl -s -X POST "$ALARM_BOT_API_URL"/api/v1/messages \
+                -u "$ALARM_BOT_EMAIL:$ALARM_BOT_API_KEY" \
+                --data-urlencode type=direct \
+                --data-urlencode "to=$ALARM_BOT_USER_EMAIL" \
+                --data-urlencode "content=$1" 1> /dev/null
+      fi
 }
 
 function alarm_check_down() {

--- a/monodb/monodb-pgsql-health.sh
+++ b/monodb/monodb-pgsql-health.sh
@@ -35,9 +35,17 @@ function print_colour() {
 }
 
 function alarm() {
-    if [ "$SEND_ALARM" == "1" ]; then
-        curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
-    fi
+      if [ "$SEND_ALARM" == "1" ]; then
+          curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
+      fi
+	
+      if [ "$SEND_DM_ALARM" = "1" ] && [ -n "$ALARM_BOT_API_KEY" ] && [ -n "$ALARM_BOT_EMAIL" ] && [ -n "$ALARM_BOT_API_URL" ] && [ -n "$ALARM_BOT_USER_EMAIL" ]; then
+            curl -s -X POST "$ALARM_BOT_API_URL"/api/v1/messages \
+                -u "$ALARM_BOT_EMAIL:$ALARM_BOT_API_KEY" \
+                --data-urlencode type=direct \
+                --data-urlencode "to=$ALARM_BOT_USER_EMAIL" \
+                --data-urlencode "content=$1" 1> /dev/null
+      fi
 }
 
 function alarm_check_down() {


### PR DESCRIPTION
This pull request adds support for direct messages on the alarm function for the monodb-mysql-health.sh and monodb-pgsql-health.sh.

You can enable it by setting `SEND_DM_ALARM` to `1` and setting `ALARM_BOT_USER_EMAIL`, `ALARM_BOT_API_KEY`, `ALARM_BOT_API_URL` and `ALARM_BOT_EMAIL` to their respective values.
