### PR TITLE
monomail-postal-health.sh, monodb-mysql/pgsql-health.sh: Add multiple alarm support

### DIFF
--- a/.bin/monodb-mysql-health.conf
+++ b/.bin/monodb-mysql-health.conf
@@ -1,8 +1,8 @@
-    ALARM_WEBHOOK_URL=example.com
+    ALARM_WEBHOOK_URLS=("example.com")
     ALARM_BOT_API_URL=https://example.com
     ALARM_BOT_EMAIL=test-bot@example.com
     ALARM_BOT_API_KEY=testkey
-    ALARM_BOT_USER_EMAIL=user@example.com
+    ALARM_BOT_USER_EMAILS=("user@example.com")
     IDENTIFIER="test"
     SEND_ALARM=1
     SEND_DM_ALARM=1

--- a/.bin/monodb-pgsql-health.conf
+++ b/.bin/monodb-pgsql-health.conf
@@ -1,8 +1,8 @@
-ALARM_WEBHOOK_URL=example.com
+ALARM_WEBHOOK_URLS=("example.com")
 ALARM_BOT_API_URL=https://example.com
 ALARM_BOT_EMAIL=test-bot@example.com
 ALARM_BOT_API_KEY=testkey
-ALARM_BOT_USER_EMAIL=user@example.com
+ALARM_BOT_USER_EMAILS=("user@example.com")
 IDENTIFIER="test"
 PATRONI_API="http://localhost:8008/cluster"
 SEND_ALARM=1

--- a/.bin/monomail-postal-health.conf
+++ b/.bin/monomail-postal-health.conf
@@ -1,6 +1,11 @@
-ALARM_WEBHOOK_URL=example.com
+ALARM_WEBHOOK_URLS=("example.com")
+ALARM_BOT_API_URL=https://example.com
+ALARM_BOT_EMAIL=test-bot@example.com
+ALARM_BOT_API_KEY=testkey
+ALARM_BOT_USER_EMAILS=("user@example.com")
 IDENTIFIER="test"
 SEND_ALARM=1
+SEND_DM_ALARM=1
 LOAD_LIMIT=10
 RAM_LIMIT=90
 message_threshold=100

--- a/monodb/monodb-mysql-health.sh
+++ b/monodb/monodb-mysql-health.sh
@@ -36,15 +36,23 @@ function print_colour() {
 
 function alarm() {
       if [ "$SEND_ALARM" == "1" ]; then
-          curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
+          if [ -z "$ALARM_WEBHOOK_URLS" ]; then
+	    curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
+	  else
+	    for webhook in "${ALARM_WEBHOOK_URLS[@]}"; do
+		curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$webhook" 1>/dev/null
+	    done
+	  fi
       fi
 	
-      if [ "$SEND_DM_ALARM" = "1" ] && [ -n "$ALARM_BOT_API_KEY" ] && [ -n "$ALARM_BOT_EMAIL" ] && [ -n "$ALARM_BOT_API_URL" ] && [ -n "$ALARM_BOT_USER_EMAIL" ]; then
-            curl -s -X POST "$ALARM_BOT_API_URL"/api/v1/messages \
-                -u "$ALARM_BOT_EMAIL:$ALARM_BOT_API_KEY" \
-                --data-urlencode type=direct \
-                --data-urlencode "to=$ALARM_BOT_USER_EMAIL" \
-                --data-urlencode "content=$1" 1> /dev/null
+      if [ "$SEND_DM_ALARM" = "1" ] && [ -n "$ALARM_BOT_API_KEY" ] && [ -n "$ALARM_BOT_EMAIL" ] && [ -n "$ALARM_BOT_API_URL" ] && [ -n "$ALARM_BOT_USER_EMAILS" ]; then
+            for user_email in "${ALARM_BOT_USER_EMAILS[@]}"; do
+		curl -s -X POST "$ALARM_BOT_API_URL"/api/v1/messages \
+		    -u "$ALARM_BOT_EMAIL:$ALARM_BOT_API_KEY" \
+		    --data-urlencode type=direct \
+		    --data-urlencode "to=$user_email" \
+		    --data-urlencode "content=$1" 1> /dev/null
+	    done
       fi
 }
 

--- a/monodb/monodb-pgsql-health.sh
+++ b/monodb/monodb-pgsql-health.sh
@@ -36,15 +36,23 @@ function print_colour() {
 
 function alarm() {
       if [ "$SEND_ALARM" == "1" ]; then
-          curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
+          if [ -z "$ALARM_WEBHOOK_URLS" ]; then
+	    curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
+	  else
+	    for webhook in "${ALARM_WEBHOOK_URLS[@]}"; do
+		curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$webhook" 1>/dev/null
+	    done
+	  fi
       fi
 	
-      if [ "$SEND_DM_ALARM" = "1" ] && [ -n "$ALARM_BOT_API_KEY" ] && [ -n "$ALARM_BOT_EMAIL" ] && [ -n "$ALARM_BOT_API_URL" ] && [ -n "$ALARM_BOT_USER_EMAIL" ]; then
-            curl -s -X POST "$ALARM_BOT_API_URL"/api/v1/messages \
-                -u "$ALARM_BOT_EMAIL:$ALARM_BOT_API_KEY" \
-                --data-urlencode type=direct \
-                --data-urlencode "to=$ALARM_BOT_USER_EMAIL" \
-                --data-urlencode "content=$1" 1> /dev/null
+      if [ "$SEND_DM_ALARM" = "1" ] && [ -n "$ALARM_BOT_API_KEY" ] && [ -n "$ALARM_BOT_EMAIL" ] && [ -n "$ALARM_BOT_API_URL" ] && [ -n "$ALARM_BOT_USER_EMAILS" ]; then
+            for user_email in "${ALARM_BOT_USER_EMAILS[@]}"; do
+		curl -s -X POST "$ALARM_BOT_API_URL"/api/v1/messages \
+		    -u "$ALARM_BOT_EMAIL:$ALARM_BOT_API_KEY" \
+		    --data-urlencode type=direct \
+		    --data-urlencode "to=$user_email" \
+		    --data-urlencode "content=$1" 1> /dev/null
+	    done
       fi
 }
 

--- a/monomail/monomail-postal-health.sh
+++ b/monomail/monomail-postal-health.sh
@@ -45,10 +45,27 @@ RESET=$(tput sgr0)
 
 if [ "$1" == "test" ]; then postal_config="./test.yaml"; else postal_config=/opt/postal/config/postal.yml; fi
 
+
 function alarm() {
-    if [ "$SEND_ALARM" == "1" ]; then
-        curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
-    fi
+      if [ "$SEND_ALARM" == "1" ]; then
+          if [ -z "$ALARM_WEBHOOK_URLS" ]; then
+	    curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$ALARM_WEBHOOK_URL" 1>/dev/null
+	  else
+	    for webhook in "${ALARM_WEBHOOK_URLS[@]}"; do
+		curl -fsSL -X POST -H "Content-Type: application/json" -d "{\"text\": \"$1\"}" "$webhook" 1>/dev/null
+	    done
+	  fi
+      fi
+	
+      if [ "$SEND_DM_ALARM" = "1" ] && [ -n "$ALARM_BOT_API_KEY" ] && [ -n "$ALARM_BOT_EMAIL" ] && [ -n "$ALARM_BOT_API_URL" ] && [ -n "$ALARM_BOT_USER_EMAILS" ]; then
+            for user_email in "${ALARM_BOT_USER_EMAILS[@]}"; do
+		curl -s -X POST "$ALARM_BOT_API_URL"/api/v1/messages \
+		    -u "$ALARM_BOT_EMAIL:$ALARM_BOT_API_KEY" \
+		    --data-urlencode type=direct \
+		    --data-urlencode "to=$user_email" \
+		    --data-urlencode "content=$1" 1> /dev/null
+	    done
+      fi
 }
 
 function get_time_diff() {

--- a/monomail/monomail-zimbra-health.sh
+++ b/monomail/monomail-zimbra-health.sh
@@ -54,7 +54,7 @@ function get_time_diff() {
     }
     service_name=$1
     service_name=$(echo "$service_name" | sed 's#/#-#g')
-    file_path="/tmp/monomail-zimbra-health/postal_${service_name}_status.txt"
+    file_path="/tmp/monomail-zimbra-health/zimbra_${service_name}_status.txt"
 
     if [ -f "${file_path}" ]; then
 
@@ -80,7 +80,7 @@ function alarm_check_down() {
         return
     }
     service_name=${1//\//-}
-    file_path="/tmp/monomail-zimbra-health/postal_${service_name}_status.txt"
+    file_path="/tmp/monomail-zimbra-health/zimbra_${service_name}_status.txt"
 
     if [ -z $3 ]; then
         if [ -f "${file_path}" ]; then
@@ -126,7 +126,7 @@ function alarm_check_up() {
         return
     }
     service_name=${1//\//-}
-    file_path="/tmp/monomail-zimbra-health/postal_${service_name}_status.txt"
+    file_path="/tmp/monomail-zimbra-health/zimbra_${service_name}_status.txt"
 
     # delete_time_diff "$1"
     if [ -f "${file_path}" ]; then
@@ -361,7 +361,7 @@ function main() {
     printf '\n'
     queued_messages
 
-    rm -rf /tmp/monomail-zimbra-health/postal_session_*_status.txt
+    rm -rf /tmp/monomail-zimbra-health/zimbra_session_*_status.txt
 }
 
 pidfile=/var/run/monomail-zimbra-health.sh.pid


### PR DESCRIPTION
This pull request adds support for multiple alarm recipients.

It adds the config variables `ALARM_WEBHOOK_URLS` and `ALARM_BOT_USER_EMAILS`. These are bash arrays.

This pull request also removes support for the config variable `ALARM_BOT_USER_EMAIL`, but compatibility with `ALARM_WEBHOOK_URL` is retained through an if-else check.

It also adds bot DM message support to `monomail-postal-health.sh`.