### PR TITLE
monocloud-health.sh: feat: FreeBSD (and derivatives) support

### DIFF
--- a/monocloud/monocloud-health.sh
+++ b/monocloud/monocloud-health.sh
@@ -198,7 +198,7 @@ check_partitions() {
         local mountpoint="${info[2]}"
         if [[ "${FILESYSTEMS[@]}" =~ "$filesystem" ]]; then
             case $filesystem in
-		"fuze.zfs")
+		"fuse.zfs")
 		    note="Fuse ZFS is not supported yet."
 		    usage="0"
 		    avail="0"


### PR DESCRIPTION
This pull request adds FreeBSD support to `monocloud-health.sh`.

To do this, it switches from getopt to manual argument parsing and makes a bunch of compatibility changes.

It also does some small improvements.

To use this in FreeBSD, there needs to be jq and bash installed on the system.